### PR TITLE
Fix install specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ os:
 
 env:
   matrix:
-    - CLI_VERSION=1.0.0.002071
+    - CLI_VERSION=1.0.0-beta-002071
     - CLI_VERSION=Latest
 
 matrix:
   allow_failures:
-    - env: CLI_VERSION=1.0.0.002071
+    - env: CLI_VERSION=1.0.0-beta-002071
 
 before_install:
   - find ./scripts -name "*.sh" -exec chmod +x {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 
 matrix:
   allow_failures:
-    - env: CLI_VERSION=1.0.0-beta-002071
+    - env: CLI_VERSION=Latest
 
 before_install:
   - find ./scripts -name "*.sh" -exec chmod +x {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,6 @@ env:
     - CLI_VERSION=1.0.0-beta-002071
     - CLI_VERSION=Latest
 
-matrix:
-  allow_failures:
-    - env: CLI_VERSION=Latest
-
 before_install:
   - find ./scripts -name "*.sh" -exec chmod +x {} \;
   - ./scripts/show-dotnet-info.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,6 @@ environment:
     - CLI_VERSION: 1.0.0-beta-002071
     - CLI_VERSION: Latest
 
-matrix:
-  allow_failures:
-    - CLI_VERSION: Latest
-
 install:
   - ps: .\scripts\show-dotnet-info.ps1
   # Download install script to install .NET cli in .dotnet dir

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 matrix:
   allow_failures:
-    - CLI_VERSION: 1.0.0-beta-002071
+    - CLI_VERSION: Latest
 
 install:
   - ps: .\scripts\show-dotnet-info.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,12 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - CLI_VERSION: 1.0.0.002071
+    - CLI_VERSION: 1.0.0-beta-002071
     - CLI_VERSION: Latest
 
 matrix:
   allow_failures:
-    - CLI_VERSION: 1.0.0.002071
+    - CLI_VERSION: 1.0.0-beta-002071
 
 install:
   - ps: .\scripts\show-dotnet-info.ps1


### PR DESCRIPTION
Now .NET CLI use semver for version ( ref https://github.com/dotnet/cli/issues/2099#issuecomment-202644846 )

`1.0.0.002071` => `1.0.0-beta-002071`

Failure are not allowed in the build matrix
